### PR TITLE
Cleanups from running rpmlint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION	:= 1.0
 INSTALL=install
 CFLAGS ?= -Wall -O2 -g
 
-DIRS	:=	src redhat
+DIRS	:=	src redhat man
 FILES 	:=	Makefile README.md
 TARBALL	:=	$(NAME)-$(VERSION).tar.xz
 
@@ -17,6 +17,8 @@ install:
 	$(INSTALL) -m 755 -d $(DESTDIR)/usr/bin $(DESTDIR)/usr/share/$(NAME)-$(VERSION)
 	$(INSTALL) starved -m 755 $(DESTDIR)/usr/bin/
 	$(INSTALL) README.md -m 644 $(DESTDIR)/usr/share/$(NAME)-$(VERSION)
+	$(INSTALL) -m 755 -d $(DESTDIR)/usr/share/man/man8
+	$(INSTALL) man/starved.8 -m 644 $(DESTDIR)/usr/share/man/man8
 
 .PHONY: clean tarball redhat
 clean:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # starved
 
-The starved program is a mechanism to prevent the *starvation* of operating
-system threads in a real-time Linux system. The premise is to start up
-on a *housekeeping* cpu (one that is not used for real-application
-purposes) and to periodically monitor the state of each thread in the
-system, looking for a thread that has been on a run queue (i.e. ready
-to run) for a specifed length of time without being run. This
-condition is usually hit when the thread is on the same cpu as a
-high-priority cpu-intensive task and therefore is being given no
-opportunity to run.
+The starved program (which stands for 'starvation daemon') is a
+mechanism to prevent the *starvation* of operating system threads in a
+Linux system. The premise is to start up on a *housekeeping* cpu (one
+that is not used for real-application purposes) and to periodically
+monitor the state of each thread in the system, looking for a thread
+that has been on a run queue (i.e. ready to run) for a specifed length
+of time without being run. This condition is usually hit when the
+thread is on the same cpu as a high-priority cpu-intensive task and
+therefore is being given no opportunity to run.
 
 When a thread is judged to be starving, starved changes
 that thread to use the SCHED_DEADLINE policy and gives the thread a

--- a/man/starved.8
+++ b/man/starved.8
@@ -1,0 +1,90 @@
+.TH STARVED 8
+.SH NAME
+starved \- detect starving threads and boost them
+.SH SYNOPSIS
+.B starved
+[ -l ] [ -v ] [ -k ] [ -s ] [ -f ] [ -h ]
+[ -c cpu-list]
+[ -p time-in-ns ]
+[ -r time-in-ns ]
+[ -d time-in-sec ]
+[ -t time-in-sec ]
+.br
+
+.SH DESCRIPTION
+.I starved
+is a system daemon that monitors thread for the starvation
+condition.
+.IR Starvation
+occurs when a thread sits on a cpu run-queue for longer
+than the starvation-threshold, meaning the thread has not
+been allowed to run for threshold seconds. The thread is
+boosted using the SCHED_DEADLINE policy and given a time
+period to run. Once it uses this boost period, the thread
+is returned to its original scheduling policy.
+
+.SH OPTIONS
+.TP
+.B \-t|\-\-starving_threshold
+how long (in seconds) a thread must starve before being boosted
+.B [60 s]
+.TP
+.B \-p|\-\-boost_period
+SCHED_DEADLINE period in nanoseconds for a starving thread
+.B [1000000000 ns]
+.TP
+.B \-r|\-\-boost_runtime
+SCHED_DEADLINE runtime in nanoseconds for a starving thread
+.B [20000 ns]
+.TP
+.B \-d|\-\-boost_duration
+duration in seconds the starving thread will run
+.B [ 3 s]
+.TP
+.B \-l|\-\-log_only
+only log information, do no boosting
+.B [false]
+.TP
+.B \-v|\\-\-verbose
+print action informtion to stdout
+.B [false]
+.TP
+.B \-k|\-\-log_kmsg
+log information to the kernel buffer
+.B [false]
+.TP
+.B \-s|\-\-log_syslog
+print information to syslog
+.B [true]
+.TP
+.B \-f|\-\-foreground
+run in the foreground
+.B [false (true with \-v)]
+.TP
+.B \-P|\-\-pidfile
+write dameon pid to specified file
+.B [none]
+.TP
+.B \-A|\-\-aggressive_mode
+dispatch one thread per cpu run-queue, even if thre are no starving
+threads (uses more power).
+.B [false]
+.TP
+.B \-h|\-\-help
+print options
+.SH FILES
+.PD 0
+.TP 20
+.B /etc/systemd/starved.conf
+parameter file for systemd startup
+.TP
+.B /usr/lib/systemd/system/starved.service
+systemd unit file
+.TP
+.B /usr/bin/starved
+starved executable
+.SH BUGS
+none
+.SH AUTHOR
+Daniel Bristot de Oliveira (bristot@redhat.com)
+Juri Lelli (juri.lelli@redhat.com)

--- a/redhat/Makefile
+++ b/redhat/Makefile
@@ -26,6 +26,10 @@ clean:
 	@rm -rf $(RPMDIRS) *~
 
 install:
-	$(INSTALL) -m 755 -d $(DESTDIR)/etc/systemd/system
+	$(INSTALL) -m 755 -d $(DESTDIR)/etc/systemd
 	$(INSTALL) starved.conf -m 644 $(DESTDIR)/etc/systemd
-	$(INSTALL) starved.service -m 644 $(DESTDIR)/etc/systemd/system
+	$(INSTALL) -m 755 -d $(DESTDIR)/usr/lib/systemd/system
+	$(INSTALL) starved.service -m 644 $(DESTDIR)/usr/lib/systemd/system
+
+rpmlint:  starved.spec
+	rpmlint -i starved.spec

--- a/redhat/starved.spec
+++ b/redhat/starved.spec
@@ -1,9 +1,9 @@
 Name:		starved
 Version:	%(grep ^VERSION ../Makefile | awk '{print $3}')
 Release:	1%{?dist}
-Summary:	daemon that finds starving tasks and gives them a temporary boost
+Summary:	Daemon that finds starving tasks and gives them a temporary boost
 
-License:	GPL
+License:	GPLv2
 URL:		https://github.com/bristot/starved
 Source0:	%{name}-%{version}.tar.xz
 
@@ -11,10 +11,12 @@ BuildRequires: glibc-devel
 Requires:      systemd
 
 %description
-The starved program monitors the set of system threads, looking for threads
-that are ready-to-run but have not been given cpu time for some threshold period. When
-a starving thread is found, it is given a temporary boost using the SCHED_DEADLINE
-policy. The default is to allow 10 microseconds of runtime for 1 second of clock time.
+The starved program monitors the set of system threads,
+looking for threads that are ready-to-run but have not
+been given processor time for some threshold period.
+When a starving thread is found, it is given a temporary
+boost using the SCHED_DEADLINE policy. The default is to
+allow 10 microseconds of runtime for 1 second of clock time.
 
 %prep
 %autosetup
@@ -26,18 +28,22 @@ policy. The default is to allow 10 microseconds of runtime for 1 second of clock
 
 %install
 rm -rf $RPM_BUILD_ROOT
-#%make_install
 make DESTDIR=$RPM_BUILD_ROOT install
 make DESTDIR=$RPM_BUILD_ROOT -C redhat install
 
 %files
-/usr/bin/%{name}
-/etc/systemd/starved.conf
-/etc/systemd/system/starved.service
+%_bindir/%{name}
+/usr/lib/systemd/system/%{name}.service
+%config(noreplace) /etc/systemd/starved.conf
 %doc /usr/share/%{name}-%{version}/README.md
 
 
 %changelog
+* Tue Aug 25 2020 williams@redhat,com - 1.0-1
+- rename project to starved
+- set version to 1.0
+- clean up rpmlint complaints
+
 * Fri Aug 21 2020 williams@redhat.com - 0.2-1
 - add pidfile logic
 

--- a/redhat/starved.spec
+++ b/redhat/starved.spec
@@ -36,7 +36,7 @@ make DESTDIR=$RPM_BUILD_ROOT -C redhat install
 /usr/lib/systemd/system/%{name}.service
 %config(noreplace) /etc/systemd/starved.conf
 %doc /usr/share/%{name}-%{version}/README.md
-
+%doc /usr/share/man/man8/starved.8.gz
 
 %changelog
 * Tue Aug 25 2020 williams@redhat,com - 1.0-1


### PR DESCRIPTION
These changes are in response to complaints from running rpmlint -i on bot the specfile and the resulting binary rpm. 
The biggest change is adding a manpage. The README.md was updated to be less real-time centric.